### PR TITLE
Fix links to new Tour of Restate in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ This tutorial takes your through key Restate features by developing an end-to-en
 
 ❓ Learn more about Restate from the [Restate documentation](https://docs.restate.dev).
 
-Have a look at the [Tour of Restate tutorial](https://docs.restate.dev/tour/typescript-handler) in the documentation to build and run the application in this repository.
+Have a look at the [Tour of Restate tutorial](https://docs.restate.dev/tour) in the documentation to build and run the application in this repository.
 
 ## Releasing
 
 In order to create a new release, push a tag of the form `vX.Y.Z`.
-Then [create a release via GitHub](https://github.com/restatedev/tour-of-restate-typescript-handler/releases).
+Then [create a release via GitHub](https://github.com/restatedev/tour-of-restate-typescript/releases).
 
 Releases of this repository are referred to by the [documentation](https://github.com/restatedev/documentation).
-Please update the version tag referenced on the [Tour of Restate](https://github.com/restatedev/documentation/blob/main/docs/tour/typescript-handler.mdx) documentation page.
+Please update the version tag referenced on the [Tour of Restate](https://github.com/restatedev/documentation/blob/main/docs/tour.mdx) documentation page.
 
 ### Upgrading Typescript SDK
 Upgrade the version tag in `package.json` and rerun the different parts of the tutorial:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@restatedev/tour-of-restate-typescript-handler",
+  "name": "@restatedev/tour-of-restate-typescript",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@restatedev/tour-of-restate-typescript-handler",
+      "name": "@restatedev/tour-of-restate-typescript",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@restatedev/tour-of-restate-typescript-handler",
+  "name": "@restatedev/tour-of-restate-typescript",
   "version": "0.0.1",
   "description": "Tour of Restate's key features with the Typescript handler API",
   "type": "commonjs",

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/app/checkout.ts
+++ b/src/app/checkout.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/app/ticket_service.ts
+++ b/src/app/ticket_service.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/app/user_session.ts
+++ b/src/app/user_session.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/aux/email_client.ts
+++ b/src/aux/email_client.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 export class EmailClient {

--- a/src/aux/payment_client.ts
+++ b/src/aux/payment_client.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 let i = 0;

--- a/src/part1/app.ts
+++ b/src/part1/app.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part1/checkout.ts
+++ b/src/part1/checkout.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part1/ticket_service.ts
+++ b/src/part1/ticket_service.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part1/user_session.ts
+++ b/src/part1/user_session.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part2/app.ts
+++ b/src/part2/app.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part2/checkout.ts
+++ b/src/part2/checkout.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part2/ticket_service.ts
+++ b/src/part2/ticket_service.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part2/user_session.ts
+++ b/src/part2/user_session.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part3/app.ts
+++ b/src/part3/app.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part3/checkout.ts
+++ b/src/part3/checkout.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part3/ticket_service.ts
+++ b/src/part3/ticket_service.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part3/user_session.ts
+++ b/src/part3/user_session.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part4/app.ts
+++ b/src/part4/app.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part4/checkout.ts
+++ b/src/part4/checkout.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part4/ticket_service.ts
+++ b/src/part4/ticket_service.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";

--- a/src/part4/user_session.ts
+++ b/src/part4/user_session.ts
@@ -6,7 +6,7 @@
  *
  * You can find a copy of the license in the file LICENSE
  * in the root directory of this repository or package or at
- * https://github.com/restatedev/tour-of-restate-typescript-handler
+ * https://github.com/restatedev/tour-of-restate-typescript
  */
 
 import * as restate from "@restatedev/restate-sdk";


### PR DESCRIPTION
After merging this, we should create a new release of this repository and update the version tag in the docs.